### PR TITLE
Add capacity reached disconnect reason

### DIFF
--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -85,6 +85,7 @@ const (
 	ParticipantCloseReasonMigrationRequested
 	ParticipantCloseReasonOvercommitted
 	ParticipantCloseReasonPublicationError
+	ParticipantCloseReasonCapacityReached
 )
 
 func (p ParticipantCloseReason) String() string {
@@ -129,6 +130,8 @@ func (p ParticipantCloseReason) String() string {
 		return "OVERCOMMITTED"
 	case ParticipantCloseReasonPublicationError:
 		return "PUBLICATION_ERROR"
+	case ParticipantCloseReasonCapacityReached:
+		return "CAPACITY_REACHED"
 	default:
 		return fmt.Sprintf("%d", int(p))
 	}
@@ -161,6 +164,8 @@ func (p ParticipantCloseReason) ToDisconnectReason() livekit.DisconnectReason {
 		return livekit.DisconnectReason_SERVER_SHUTDOWN
 	case ParticipantCloseReasonNegotiateFailed, ParticipantCloseReasonPublicationError:
 		return livekit.DisconnectReason_STATE_MISMATCH
+	case ParticipantCloseReasonCapacityReached:
+		return livekit.DisconnectReason_CAPACITY_REACHED
 	default:
 		// the other types will map to unknown reason
 		return livekit.DisconnectReason_UNKNOWN_REASON


### PR DESCRIPTION
Allows for server to signal to the participant that the room has reached max capacity.